### PR TITLE
Readme: Added links to [IMP Doc] & [DHP]

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ There will be more documentation about this, once it is more mature.
 
 ## Contributing
 Just make a pull request :D  
-All functions should be documented using IMP doc.  
-It is recommended to use the VS code extension Datapack Helper Plus. There are some custom settings in this repository that will automatically be applied to your repository and ensure you follow my conventions.
+All functions should be documented using [IMP doc](https://github.com/SPYGlassMC/SPYGlass/wiki/IMP-Doc).  
+It is recommended to use the VS code extension [Datapack Helper Plus](https://marketplace.visualstudio.com/items?itemName=SPGoding.datapack-language-server). There are some custom settings in this repository that will automatically be applied to your repository and ensure you follow my conventions.
 
 ## Credits
 NeunEinser: The map  


### PR DESCRIPTION
Added them for convenience for people [not knowing DHP] / [starting coding in mcfunctions].
Personally I've finally found IMP after thinking that it may be linked in [DHP] documentation.
https://github.com/NeunEinser/bingo/blob/b9903f5e39302239311506b8c576d06f746746e1/README.md#L42-L43

*`line 42` (IMP): can also be linked directly to source: https://github.com/Arcensoth/imp-spec