### PR TITLE
Fix for issue 248 - biome parse errors on pre 1.21.2

### DIFF
--- a/datapack/data/minecraft/worldgen/biome/savanna_plateau.json
+++ b/datapack/data/minecraft/worldgen/biome/savanna_plateau.json
@@ -1,9 +1,11 @@
 {
-	"carvers": [
-		"minecraft:cave",
-		"minecraft:cave_extra_underground",
-		"minecraft:canyon"
-	],
+	"carvers": {
+		"air": [
+			"minecraft:cave",
+			"minecraft:cave_extra_underground",
+			"minecraft:canyon"
+		]
+	},
 	"downfall": 0.0,
 	"effects": {
 		"fog_color": 12638463,

--- a/datapack/data/minecraft/worldgen/biome/windswept_savanna.json
+++ b/datapack/data/minecraft/worldgen/biome/windswept_savanna.json
@@ -1,9 +1,11 @@
 {
-	"carvers": [
-		"minecraft:cave",
-		"minecraft:cave_extra_underground",
-		"minecraft:canyon"
-	],
+	"carvers": {
+		"air": [
+			"minecraft:cave",
+			"minecraft:cave_extra_underground",
+			"minecraft:canyon"
+		]
+	},
 	"downfall": 0.0,
 	"effects": {
 		"fog_color": 12638463,

--- a/datapack/pack.mcmeta
+++ b/datapack/pack.mcmeta
@@ -6,6 +6,7 @@
 	},
 	"overlays": {
 		"entries": [
+			{ "directory": "pack_format_from_49", "formats": {"min_inclusive": 49, "max_inclusive": 2147483647} },
 			{ "directory": "pack_format_from_58", "formats": {"min_inclusive": 58, "max_inclusive": 2147483647} },
 			{ "directory": "pack_format_from_59", "formats": {"min_inclusive": 59, "max_inclusive": 2147483647} }
 		]

--- a/datapack/pack_format_from_49/data/minecraft/worldgen/biome/savanna.json
+++ b/datapack/pack_format_from_49/data/minecraft/worldgen/biome/savanna.json
@@ -1,11 +1,9 @@
 {
-	"carvers": {
-		"air": [
-			"minecraft:cave",
-			"minecraft:cave_extra_underground",
-			"minecraft:canyon"
-		]
-	},
+	"carvers": [
+		"minecraft:cave",
+		"minecraft:cave_extra_underground",
+		"minecraft:canyon"
+	],
 	"downfall": 0.0,
 	"effects": {
 		"fog_color": 12638463,

--- a/datapack/pack_format_from_49/data/minecraft/worldgen/biome/savanna_plateau.json
+++ b/datapack/pack_format_from_49/data/minecraft/worldgen/biome/savanna_plateau.json
@@ -1,11 +1,9 @@
 {
-	"carvers": {
-		"air": [
-			"minecraft:cave",
-			"minecraft:cave_extra_underground",
-			"minecraft:canyon"
-		]
-	},
+	"carvers": [
+		"minecraft:cave",
+		"minecraft:cave_extra_underground",
+		"minecraft:canyon"
+	],
 	"downfall": 0.0,
 	"effects": {
 		"fog_color": 12638463,
@@ -138,7 +136,19 @@
 				"type": "minecraft:armadillo",
 				"maxCount": 3,
 				"minCount": 2,
-				"weight": 52
+				"weight": 68
+			},
+			{
+				"type": "minecraft:llama",
+				"maxCount": 4,
+				"minCount": 4,
+				"weight": 8
+			},
+			{
+				"type": "minecraft:wolf",
+				"maxCount": 8,
+				"minCount": 4,
+				"weight": 8
 			}
 		],
 		"misc": [],

--- a/datapack/pack_format_from_49/data/minecraft/worldgen/biome/windswept_savanna.json
+++ b/datapack/pack_format_from_49/data/minecraft/worldgen/biome/windswept_savanna.json
@@ -1,11 +1,9 @@
 {
-	"carvers": {
-		"air": [
-			"minecraft:cave",
-			"minecraft:cave_extra_underground",
-			"minecraft:canyon"
-		]
-	},
+	"carvers": [
+		"minecraft:cave",
+		"minecraft:cave_extra_underground",
+		"minecraft:canyon"
+	],
 	"downfall": 0.0,
 	"effects": {
 		"fog_color": 12638463,
@@ -72,10 +70,9 @@
 		],
 		[
 			"minecraft:glow_lichen",
-			"minecraft:patch_tall_grass",
-			"minecraft:trees_savanna",
-			"minecraft:flower_warm",
-			"minecraft:patch_grass_savanna",
+			"minecraft:trees_windswept_savanna",
+			"minecraft:flower_default",
+			"minecraft:patch_grass_normal",
 			"minecraft:brown_mushroom_normal",
 			"minecraft:red_mushroom_normal",
 			"minecraft:patch_sugar_cane",


### PR DESCRIPTION
Fix for issue 248 - biome parse errors on pre 1.21.2

Uses the correct format biome definitions from both 1.21.0 and 1.21.2 (the latter via an overlay folder, which takes effect starting with data pack version 49 from snapshot 24w33a onwards)

Tested with this fix, and was able to open the world successfully in both 1.21.0 and 1.21.2